### PR TITLE
Wrap column names in double quotes (") to handle case sensitivity

### DIFF
--- a/CloneRow.py
+++ b/CloneRow.py
@@ -616,9 +616,9 @@ class CloneRow(object):
         columns = [c for c in delta_columns if c not in self.database['ignore_columns']]
         for column in columns:
             if not update_sql:
-                update_sql = 'update {0} set {1} = %s'.format(self.database['table'], column)
+                update_sql = 'update {0} set "{1}" = %s'.format(self.database['table'], column)
             else:
-                update_sql += ', {0} = %s'.format(column)
+                update_sql += ', "{0}" = %s'.format(column)
             update_params.append(self.target['connection'].adapt_param(self.source['row'][column]))
         update_sql += ' where {0} = %s'.format(self.database['column'])
         update_params.append(self.database['filter'])


### PR DESCRIPTION
guest.updatedAt would shit the bed without quotes around "updatedAt" like

```
Traceback (most recent call last):
  File "/Users/wulfsolter/Code/clone-row/CloneRow.py", line 670, in <module>
    DOLLY.update_target()
  File "/Users/wulfsolter/Code/clone-row/CloneRow.py", line 626, in update_target
    cur.execute(update_sql, tuple(update_params))
psycopg2.ProgrammingError: column "updatedat" of relation "guest" does not exist
LINE 1: ...ise_record = 'true', where_hear_other = 'Friend', updatedAt ...
                                                         ^
```
