### PR TITLE
Fix missing leading and tailing double quotes

### DIFF
--- a/CloneRow.py
+++ b/CloneRow.py
@@ -458,7 +458,7 @@ class CloneRow(object):
             placeholders.append('%s')
         logging.info('inserting a minimal row into target database.. ')
         cur = self.target['connection'].cursor()
-        insert_sql = 'insert into "{0}" ({1}) values ({2})'.format(
+        insert_sql = 'insert into "{0}" ("{1}") values ({2})'.format(
             self.database['table'], '", "'.join(columns), ', '.join(placeholders)
         )
         # what we're doing here is just putting a single row containing the column


### PR DESCRIPTION
Glorious leader made a 3am commit that broke CloneRow when inserting column names that need double quotes.
Fixy fixy fixy